### PR TITLE
feat: gh action verification

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,29 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@0.0.7
+      - uses: aviate-labs/setup-dfx@v0.2.5
+        with:
+          dfx-version: 0.13.1
+          install-moc: true
+          vessel-version: 0.6.5
+      - run: npm ci && npm run setup && npm run verify
+
+  verify-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: aviate-labs/setup-dfx@v0.2.5
+        with:
+          dfx-version: 0.13.1
+          install-moc: true
+          vessel-version: 0.6.5
+      - run: npm ci && npm run setup && npm run verify
+
+  verify-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: aviate-labs/setup-dfx@v0.2.5
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@0.0.6
+      - uses: jorgenbuilder/setup-dfx@0.0.7
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx
+      - uses: jorgenbuilder/setup-dfx@0.0.2
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@0.0.2
+      - uses: jorgenbuilder/setup-dfx@0.0.3
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: aviate-labs/setup-dfx@v0.2.3
+      - uses: jorgenbuilder/setup-dfx@v0.2.3
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,4 +11,5 @@ jobs:
         with:
           dfx-version: 0.13.1
           install-moc: true
+          vessel-version: v0.6.5
       - run: npm ci && npm run setup && npm run verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@v0.2.3
+      - uses: jorgenbuilder/setup-dfx@v0.0.1
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@0.0.1
+      - uses: jorgenbuilder/setup-dfx@latest
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@0.0.3
+      - uses: jorgenbuilder/setup-dfx@0.0.4
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,25 +13,3 @@ jobs:
           install-moc: true
           vessel-version: 0.6.5
       - run: npm ci && npm run setup && npm run verify
-
-  verify-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: aviate-labs/setup-dfx@v0.2.5
-        with:
-          dfx-version: 0.13.1
-          install-moc: true
-          vessel-version: 0.6.5
-      - run: npm ci && npm run setup && npm run verify
-
-  verify-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: aviate-labs/setup-dfx@v0.2.5
-        with:
-          dfx-version: 0.13.1
-          install-moc: true
-          vessel-version: 0.6.5
-      - run: npm ci && npm run setup && npm run verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@latest
+      - uses: jorgenbuilder/setup-dfx
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@0.0.5
+      - uses: jorgenbuilder/setup-dfx@0.0.6
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,25 +13,3 @@ jobs:
           install-moc: true
           vessel-version: 0.6.5
       - run: npm ci && npm run setup && npm run verify
-
-  verify-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@0.0.7
-        with:
-          dfx-version: 0.13.1
-          install-moc: true
-          vessel-version: 0.6.5
-      - run: npm ci && npm run setup && npm run verify
-
-  verify-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@0.0.7
-        with:
-          dfx-version: 0.13.1
-          install-moc: true
-          vessel-version: 0.6.5
-      - run: npm ci && npm run setup && npm run verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,3 +13,14 @@ jobs:
           install-moc: true
           vessel-version: 0.6.5
       - run: npm ci && npm run setup && npm run verify
+
+  verify-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jorgenbuilder/setup-dfx@0.0.7
+        with:
+          dfx-version: 0.13.1
+          install-moc: true
+          vessel-version: 0.6.5
+      - run: npm ci && npm run setup && npm run verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@v0.0.1
+      - uses: jorgenbuilder/setup-dfx@0.0.1
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,14 @@
+name: Verify Black Hole Canister
+on:
+  - push
+  - workflow_dispatch
+jobs:
+  verify:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: aviate-labs/setup-dfx@v0.2.3
+        with:
+          dfx-version: 0.13.1
+          install-moc: true
+      - run: npm ci && npm run setup && npm run verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jorgenbuilder/setup-dfx@0.0.4
+      - uses: jorgenbuilder/setup-dfx@0.0.5
         with:
           dfx-version: 0.13.1
           install-moc: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           dfx-version: 0.13.1
           install-moc: true
-          vessel-version: v0.6.5
+          vessel-version: 0.6.5
       - run: npm ci && npm run setup && npm run verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -24,3 +24,14 @@ jobs:
           install-moc: true
           vessel-version: 0.6.5
       - run: npm ci && npm run setup && npm run verify
+
+  verify-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jorgenbuilder/setup-dfx@0.0.7
+        with:
+          dfx-version: 0.13.1
+          install-moc: true
+          vessel-version: 0.6.5
+      - run: npm ci && npm run setup && npm run verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,7 +6,7 @@ jobs:
   verify:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: aviate-labs/setup-dfx@v0.2.5
         with:
           dfx-version: 0.13.1

--- a/node/os.ts
+++ b/node/os.ts
@@ -4,7 +4,7 @@ export function verifyOS(): void {
   const isMac = os.platform() === "darwin";
   if (!isMac)
     throw new Error(
-      "Verification must be performed on macos! The easiest way to do this is with a github action (see https://github.com/CycleOperators/BalanceCheckerVerification). This is due to differences in build environments resulting in different wasm hashes."
+      "Verification must be performed on macos! The easiest way to do this is with a github action. See https://github.com/CycleOperators/BalanceCheckerVerification for github action instructions. This is due to differences in build environments resulting in different wasm hashes."
     );
 }
 

--- a/node/os.ts
+++ b/node/os.ts
@@ -1,0 +1,11 @@
+import os from "os";
+
+export function verifyOS(): void {
+  const isMac = os.platform() === "darwin";
+  if (!isMac)
+    throw new Error(
+      "Verification must be performed on macos! The easiest way to do this is with a github action (see https://github.com/CycleOperators/BalanceCheckerVerification). This is due to differences in build environments resulting in different wasm hashes."
+    );
+}
+
+if (!module.parent) verifyOS();

--- a/node/verify.ts
+++ b/node/verify.ts
@@ -1,5 +1,6 @@
 import fs from "fs-extra";
 import { execSync } from "child_process";
+import { verifyOS } from './os';
 
 /**
  * Retrieve black hole canister ID on mainnet.
@@ -42,6 +43,7 @@ function retrieveControllersAndModuleHash(
  * Verifies the status of the mainnet black hole canister in this repository.
  */
 async function run() {
+  verifyOS();
   const canisterLocal = await blackholeCanisterIdLocal();
   const canisterMainnet = await blackholeMainnetCanisterId();
   console.log(`Verifiying canister ${await blackholeMainnetCanisterId()}...`);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Demonstrates methodology for verifying black hole status and source code",
   "scripts": {
     "verify-blackhole": "npm ci && npm run setup && npm run verify",
-    "setup": "dfx stop && dfx start --clean --background && dfx deploy && npm run remove-controllers-local",
+    "setup": "npx ts-node ./os && dfx stop && dfx start --clean --background && dfx deploy && npm run remove-controllers-local",
     "remove-controllers-local": "dfx canister update-settings blackhole --remove-controller $(dfx identity get-wallet) && dfx canister update-settings blackhole --remove-controller $(dfx identity get-principal)",
     "declarations": "npx ts-node ./tasks/declarations",
     "pretty": "npx prettier --write \"**/*.ts(x)?\"",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Demonstrates methodology for verifying black hole status and source code",
   "scripts": {
     "verify-blackhole": "npm ci && npm run setup && npm run verify",
-    "setup": "npx ts-node ./os && dfx stop && dfx start --clean --background && dfx deploy && npm run remove-controllers-local",
+    "setup": "npx ts-node ./node/os && dfx stop && dfx start --clean --background && dfx deploy && npm run remove-controllers-local",
     "remove-controllers-local": "dfx canister update-settings blackhole --remove-controller $(dfx identity get-wallet) && dfx canister update-settings blackhole --remove-controller $(dfx identity get-principal)",
     "declarations": "npx ts-node ./tasks/declarations",
     "pretty": "npx prettier --write \"**/*.ts(x)?\"",

--- a/readme.md
+++ b/readme.md
@@ -1,29 +1,47 @@
 ## Introduction
-* This repository contains the [source code](blackhole.mo) for canister `5vdms-kaaaa-aaaap-aa3uq-cai`, the CycleOps balance checker canister
-* It contains scripts allowing a user to verify that canister `5vdms-kaaaa-aaaap-aa3uq-cai` is:
-  * blackholed, with 0 controllers
-  * running the same wasm binary generated from ([./blackhole.mo](blackhole.mo))
+
+- This repository contains the [source code](blackhole.mo) for canister `5vdms-kaaaa-aaaap-aa3uq-cai`, the CycleOps balance checker canister
+- It contains scripts allowing a user to verify that canister `5vdms-kaaaa-aaaap-aa3uq-cai` is:
+  - blackholed, with 0 controllers
+  - running the same wasm binary generated from ([./blackhole.mo](blackhole.mo))
 
 <br/>
 
 # Verification of the Blackholed Balance Checker canister
+
+## Easy Mode: Use a GH Action
+
+This will only take a few clicks!
+
+1. Fork this repository.
+2. Navigate to the actions tab of your new repo.
+3. Select the "Verify Black Hole Canister" action on the left.
+4. Dispatch the action.
+
+You can view the output of this action to confirm that 1) the canister has no controllers, 2) the mainnet wasm matches the contents of this repository. The final step to be 100% confident that this canister can do no harm is to audit the source code of this repo.
+
+## Alternative: Verify on your local machine
+
+_NOTE: wasm hash will vary depending on operating system. You must use macos to verify the wasm hash._
 
 To verify the CycleOps balance checker canister's black hole status from your local machine:
 
 1. Clone this repository
 2. Install version 0.13.1 of dfx (the version listed in the `dfx.json` file) with `DFX_VERSION=0.13.1 sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"`. [dfx](https://internetcomputer.org/docs/current/references/cli-reference/dfx-parent/) is the DFINITY command-line execution environment for creating, deploying, and managing the dapps you develop for the IC.
 3. Install vessel from (https://github.com/dfinity/vessel). Vessel is used to fix the version of the [motoko-base](https://github.com/dfinity/motoko-base) library used in the project to 0.8.4.
-3. The following command:
+4. The following command:
 
    a. Spins up a local dfx instance and deploys a copy of the CycleOps balance checker canister from the code in `blackhole.mo` in this repository.
 
    b. It then compares the wasm hash of that module against the hash of the wasm module stored in `5vdms-kaaaa-aaaap-aa3uq-cai`, the canister id of the CycleOps balance checker canister running on main net.
-   
+
    c. It also verifies that `5vdms-kaaaa-aaaap-aa3uq-cai` has no controllers.
+
    ```sh
-   npm run verify-blackhole 
+   npm run verify-blackhole
    ```
-4. You should see the following in the local logs:
+
+5. You should see the following in the local logs:
 
    ![successful action logs](./assets/local-log.png)
 
@@ -68,7 +86,6 @@ We provide users with a methodology to perform these validations independently, 
 <br/>
 
 # Disclaimers
-* This repository does not contain a license, meaninig reuse is only on permitted on per-use case basis. Please contact the CycleOps team if you would like to use this code in your application.
-* This software is provided "as is", without warranty of any kind. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software
 
-
+- This repository does not contain a license, meaninig reuse is only on permitted on per-use case basis. Please contact the CycleOps team if you would like to use this code in your application.
+- This software is provided "as is", without warranty of any kind. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ You can view the output of this action to confirm that 1) the canister has no co
 
 ## Alternative: Verify on your local machine
 
-_NOTE: wasm hash will vary depending on operating system. You must use macos to verify the wasm hash._
+_NOTE: Currently, this method is only supported for macOS, as the wasm hash generated will vary depending on operating system._
 
 To verify the CycleOps balance checker canister's black hole status from your local machine:
 


### PR DESCRIPTION
- adds a gh action to allow for easy verification of the balance checker.
- adds a warning to the verification script when run on an operating system other than macos, with instructions on how to verify using the gh action.
- updates the readme to encourage use of the gh action.